### PR TITLE
update Enspiral Craftworks logo

### DIFF
--- a/groups/enspiral-craftworks.yml
+++ b/groups/enspiral-craftworks.yml
@@ -1,6 +1,6 @@
 '@type': Group
 name: Enspiral Craftworks
-image: http://i.imgur.com/BFmaOxi.png
+image: http://i.imgur.com/ErXtiQw.png
 relationships:
   - '@type': Relationship
     type: relationshipTypes/set


### PR DESCRIPTION
@simontegg this logo doesn't quite fit the circular clip path. just an idea, maybe group avatars are squares instead of circles? it also fits the metaphor i've heard about groups commonly being "windows" or "doors" to the outside.
